### PR TITLE
Initial commit of submission publishing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ Make sure you have installed Pyblish before continuing.
 
 ## Introduction
 
-The integration comes in the form of a menu-item called *"Publish"*, located directly under the right-click menu on the timeline.
+With this integration you can publish from two places in NukeStudio;
 
-Once clicked, it will display a Pyblish graphical user interface.
+- Menu-item called *"Publish"*, located directly under the right-click menu on the timeline.
+- Submission called *"Pyblish"*, located in the export dialog in the dropdown menu *"Render with:"*.
+
+This will display a Pyblish graphical user interface.
 
 ## Installation
 
@@ -60,5 +63,11 @@ This is the current selection on the timeline.
 
 ### ```context.data["activeProject"]```
 
-
 This is the project being published from.
+
+### ```context.data["submission"]```
+
+This is the submission object from the export dialog. This is TaskGroup which you can read more about here;
+
+https://www.thefoundry.co.uk/products/hiero/developers/10.5/hieropythondevguide/export.html
+https://www.thefoundry.co.uk/products/hiero/developers/10.5/hieropythondevguide/api/api_core.html#hiero.core.TaskGroup

--- a/pyblish_nukestudio/lib.py
+++ b/pyblish_nukestudio/lib.py
@@ -151,6 +151,12 @@ class PublishAction(QtGui.QAction):
 
     def publish(self):
         import pyblish_nukestudio
+
+        # Removing "submission" attribute from hiero module, to prevent tasks
+        # from getting picked up when not using the "Export" dialog.
+        if hasattr(hiero, "submission"):
+            del hiero.submission
+
         pyblish_nukestudio.show()
 
     def eventHandler(self, event):

--- a/pyblish_nukestudio/lib.py
+++ b/pyblish_nukestudio/lib.py
@@ -39,6 +39,7 @@ def setup(console=False, port=None, menu=True):
 
     register_plugins()
     register_host()
+    add_submission()
 
     if menu:
         add_to_filemenu()
@@ -118,6 +119,22 @@ def register_plugins():
 
 def add_to_filemenu():
     PublishAction()
+
+
+class PyblishSubmission(hiero.exporters.FnSubmission.Submission):
+
+    def __init__(self):
+        hiero.exporters.FnSubmission.Submission.__init__(self)
+
+    def addToQueue(self):
+        # Add submission to Hiero module for retrieval in plugins.
+        hiero.submission = self
+        show()
+
+
+def add_submission():
+    registry = hiero.core.taskRegistry
+    registry.addSubmission("Pyblish", PyblishSubmission)
 
 
 class PublishAction(QtGui.QAction):

--- a/pyblish_nukestudio/plugins/collect_submission.py
+++ b/pyblish_nukestudio/plugins/collect_submission.py
@@ -9,4 +9,5 @@ class CollectSubmission(pyblish.api.ContextPlugin):
     def process(self, context):
         import hiero
 
-        context.data["submission"] = hiero.submission
+        if hasattr(hiero, "submission"):
+            context.data["submission"] = hiero.submission

--- a/pyblish_nukestudio/plugins/collect_submission.py
+++ b/pyblish_nukestudio/plugins/collect_submission.py
@@ -1,0 +1,13 @@
+import hiero
+
+import pyblish.api
+
+
+class CollectSubmission(pyblish.api.ContextPlugin):
+    """Collect submisson children."""
+
+    order = pyblish.api.CollectorOrder - 0.1
+
+    def process(self, context):
+
+        context.data["submission"] = hiero.submission

--- a/pyblish_nukestudio/plugins/collect_submission.py
+++ b/pyblish_nukestudio/plugins/collect_submission.py
@@ -1,5 +1,3 @@
-import hiero
-
 import pyblish.api
 
 
@@ -9,5 +7,6 @@ class CollectSubmission(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder - 0.1
 
     def process(self, context):
+        import hiero
 
         context.data["submission"] = hiero.submission


### PR DESCRIPTION
This PR extends the integration with an option to use Pyblish in the export dialog.

This allows developers to get all the exports the users want and validate and extract those. The user can now follow the normal workflow in NukeStudio of setting up presets to export, but still be publishing through Pyblish.

Unfortunately I wouldn't say the documentation for the exporting and submission is very extensive, but hopefully that'll change in the future.